### PR TITLE
Fix Render YAML indentation for service config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-  name: gemini-api-proxy
+    name: gemini-api-proxy
     env: python
     plan: free
     region: oregon


### PR DESCRIPTION
## Summary
- correct the indentation of the Render service definition so the manifest parses as valid YAML

## Testing
- python -m compileall app/admin/api_routes.py app/admin/api_services.py app/admin/database.py app/tools/code_executor.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f28862a68832e8fb493ce67a4b79a)